### PR TITLE
Fix infinite loop #4, fix warnings.

### DIFF
--- a/module.json
+++ b/module.json
@@ -40,10 +40,10 @@
   "url": "#{URL}#",
   "manifest": "#{MANIFEST}#",
   "download": "#{DOWNLOAD}#",
-  "readme": "https://github.com/ReAcTiOnN77/combat-exhaustion/blob/master/README.md",
-  "changelog": "https://github.com/ReAcTiOnN77/combat-exhaustion/blob/master/CHANGELOG.md",
-  "license": "https://github.com/ReAcTiOnN77/combat-exhaustion/blob/master/LICENSE",
-  "bugs": "https://github.com/ReAcTiOnN77/combat-exhaustion/issues",
+  "readme": "https://github.com/Trentone/combat-exhaustion/blob/master/README.md",
+  "changelog": "https://github.com/Trentone/combat-exhaustion/blob/master/CHANGELOG.md",
+  "license": "https://github.com/Trentone/combat-exhaustion/blob/master/LICENSE",
+  "bugs": "https://github.com/Trentone/combat-exhaustion/issues",
   "media": [
     {
       "type": "icon",

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -7,7 +7,7 @@ export function isActorInCombat(actor) {
 
 // Helper function to update actor's exhaustion
 export async function updateExhaustion(actor, amount) {
-  let exhaustion = getProperty(actor, "system.attributes.exhaustion");
+  let exhaustion = foundry.utils.getProperty(actor, "system.attributes.exhaustion");
   logDebug(`Current exhaustion value: ${exhaustion} (type: ${typeof exhaustion})`);
 
   exhaustion = parseInt(exhaustion ?? 0, 10);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -14,8 +14,11 @@ Hooks.on("ready", () => {
 Hooks.on("updateActor", async (actor, updateData) => {
 	if (!actor.hasPlayerOwner && !game.user.isGM) return;
 	
-	const hpValue = foundry.utils.getProperty(updateData, "system.attributes.hp.value");
+	let hpValue = foundry.utils.getProperty(updateData, "system.attributes.hp.value");
 	const prevHpValue = actor.getFlag(MODULE_ID, "previousHp") ?? foundry.utils.getProperty(actor, "system.attributes.hp.value");
+	if (typeof hpValue === 'undefined')
+		hpValue = prevHpValue;
+	
 	const exhaustionMode = game.settings.get(MODULE_ID, "exhaustionMode");
 	const exhaustOnFirstDeathFail = game.settings.get(MODULE_ID, "exhaustOnFirstDeathFail");
 	const enableConSave = game.settings.get(MODULE_ID, "enableConSave");

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -14,8 +14,8 @@ Hooks.on("ready", () => {
 Hooks.on("updateActor", async (actor, updateData) => {
 	if (!actor.hasPlayerOwner && !game.user.isGM) return;
 	
-	const hpValue = getProperty(updateData, "system.attributes.hp.value");
-	const prevHpValue = actor.getFlag(MODULE_ID, "previousHp") ?? getProperty(actor, "system.attributes.hp.value");
+	const hpValue = foundry.utils.getProperty(updateData, "system.attributes.hp.value");
+	const prevHpValue = actor.getFlag(MODULE_ID, "previousHp") ?? foundry.utils.getProperty(actor, "system.attributes.hp.value");
 	const exhaustionMode = game.settings.get(MODULE_ID, "exhaustionMode");
 	const exhaustOnFirstDeathFail = game.settings.get(MODULE_ID, "exhaustOnFirstDeathFail");
 	const enableConSave = game.settings.get(MODULE_ID, "enableConSave");


### PR DESCRIPTION
Fixes infinite loop #4 and warnings. 
Tested on Foundry 12.331 with DnD 4.4.3
Tested with "Exhaustion Mode" - "Always Apply" and "Exhaustion on First Death Save Failure" both on and off. Works correctly. Should work with other settings good as well.